### PR TITLE
feature added: checking the condition number in VkDSampler

### DIFF
--- a/cma/restricted_gaussian_sampler.py
+++ b/cma/restricted_gaussian_sampler.py
@@ -618,8 +618,7 @@ class GaussVkDSampler(StatisticalModelSamplerWithZeroMeanBaseClass):
 
     @property
     def condition_number(self):
-        """Condition number of the inside matrix (I + VV')"""
-        return self.S
+        raise NotImplementedError
 
     @property
     def covariance_matrix(self):

--- a/cma/restricted_gaussian_sampler.py
+++ b/cma/restricted_gaussian_sampler.py
@@ -618,7 +618,8 @@ class GaussVkDSampler(StatisticalModelSamplerWithZeroMeanBaseClass):
 
     @property
     def condition_number(self):
-        raise NotImplementedError
+        """Condition number of the inside matrix (I + VV')"""
+        return self.S
 
     @property
     def covariance_matrix(self):
@@ -701,6 +702,21 @@ class GaussVkDSampler(StatisticalModelSamplerWithZeroMeanBaseClass):
         return 2.0 * np.sum(np.log(self.D)) + np.sum(
             np.log(1.0 + self.S[:self.k_active]))
 
+    def get_condition_numbers(self):
+        """get the condition numbers of D**2 and (I + VV')
+        
+        Theoretically, the condition number of the covariance matrix can be
+        at most the product of the return values. It might be safe to stop 
+        a run if the product of the return values reaches 1e14.
+
+        Returns
+        -------
+        float
+            condition number of D
+        float 
+            condition number of I + VV'
+        """
+        return (np.max(self.D) / np.min(self.D)) ** 2, np.max(1 + self.S[:self.k])
 
 class ExponentialMovingAverage(object):
     """Exponential Moving Average, Variance, and SNR (Signal-to-Noise Ratio)


### PR DESCRIPTION
Related with the issue #46, I implemented a method to check the condition numbers of the outside and the inside matrices. The method itself is trivial, but the comment of the method will be helpful. One can implement his/her own stopping condition using the provided method.