### PR TITLE
fixed issue 57 as suggested by @dtusar

### DIFF
--- a/cma/bbobbenchmarks.py
+++ b/cma/bbobbenchmarks.py
@@ -328,7 +328,7 @@ def fGauss(ftrue, beta):
     idx = ftrue < tol
     try:
         fval[idx] = ftrue[idx]
-    except IndexError: # fval is a scalar
+    except (IndexError, TypeError): # fval is a scalar
         if idx:
             fval = ftrue
     return fval
@@ -344,7 +344,7 @@ def fUniform(ftrue, alpha, beta):
     idx = ftrue < tol
     try:
         fval[idx] = ftrue[idx]
-    except IndexError: # fval is a scalar
+    except (IndexError, TypeError): # fval is a scalar
         if idx:
             fval = ftrue
     return fval
@@ -366,7 +366,7 @@ def fCauchy(ftrue, alpha, p):
     idx = ftrue < tol
     try:
         fval[idx] = ftrue[idx]
-    except IndexError: # fval is a scalar
+    except (IndexError, TypeError): # fval is a scalar
         if idx:
             fval = ftrue
     return fval


### PR DESCRIPTION
The reason for the problems in issue #57 are due to a change in the error type that is raised by numpy as @dtusar found out while using the `bbobbenchmarks.py` in the new `cocoex2` module. The current pull request solves this issue, at least on my computer.