### PR TITLE
Factor 10 performance improvement for Diagonal CMA

### DIFF
--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -3414,10 +3414,10 @@ class _CMAStopDict(dict):
         # tolx, tolfacupx: generic criteria
         # tolfun, tolfunhist (CEC:tolfun includes hist)
         self._addstop('tolx',
-                      all([es.sigma * xi < opts['tolx'] for xi in es.sigma_vec * es.pc]) and
-                      all([es.sigma * xi < opts['tolx'] for xi in es.sigma_vec * np.sqrt(es.dC)]))
+                      np.all(es.sigma * (es.sigma_vec * es.pc) < opts['tolx']) and
+                      np.all(es.sigma * (es.sigma_vec * np.sqrt(es.dC)) < opts['tolx']))
         self._addstop('tolfacupx',
-                      any(es.sigma * es.sigma_vec.scaling * es.dC**0.5 >
+                      np.any(es.sigma * es.sigma_vec.scaling * es.dC**0.5 >
                           es.sigma0 * es.sigma_vec0 * opts['tolfacupx']))
         self._addstop('tolfun',
                       es.fit.fit[-1] - es.fit.fit[0] < opts['tolfun'] and

--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -2996,10 +2996,10 @@ class CMAEvolutionStrategy(interfaces.OOOptimizer):
         As a result, `C` is a correlation matrix, i.e., all diagonal
         entries of `C` are `1`.
         """
-        if condition and np.isfinite(condition) and max(self.dC) / min(self.dC) > condition:
+        if condition and np.isfinite(condition) and np.max(self.dC) / np.min(self.dC) > condition:
             # allows for much larger condition numbers, if axis-parallel
             if hasattr(self, 'sm') and isinstance(self.sm, sampler.GaussFullSampler):
-                old_coordinate_condition = max(self.dC) / min(self.dC)
+                old_coordinate_condition = np.max(self.dC) / np.min(self.dC)
                 old_condition = self.sm.condition_number
                 factors = self.sm.to_correlation_matrix()
                 self.sigma_vec *= factors
@@ -3008,7 +3008,7 @@ class CMAEvolutionStrategy(interfaces.OOOptimizer):
                 utils.print_message('\ncondition in coordinate system exceeded'
                                     ' %.1e, rescaled to %.1e, '
                                     '\ncondition changed from %.1e to %.1e'
-                                      % (old_coordinate_condition, max(self.dC) / min(self.dC),
+                                      % (old_coordinate_condition, np.max(self.dC) / np.min(self.dC),
                                          old_condition, self.sm.condition_number),
                                     iteration=self.countiter)
 

--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -2107,7 +2107,7 @@ class CMAEvolutionStrategy(interfaces.OOOptimizer):
                            "_random_rescaling_factor_to_mahalanobis_size",
                                 iteration=self.countiter)
             return 1.0
-        return sum(self.randn(1, len(y))[0]**2)**0.5 / self.mahalanobis_norm(y)
+        return np.sum(self.randn(1, len(y))[0]**2)**0.5 / self.mahalanobis_norm(y)
 
 
     def get_mirror(self, x, preserve_length=False):

--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -3477,7 +3477,7 @@ class _CMAStopDict(dict):
                 i = es.countiter % N
                 try:
                     self._addstop('noeffectaxis',
-                                 sum(es.mean == es.mean + 0.1 * es.sigma *
+                                 np.sum(es.mean == es.mean + 0.1 * es.sigma *
                                      es.sm.D[i] * es.sigma_vec.scaling *
                                      (es.sm.B[:, i] if len(es.sm.B.shape) > 1 else es.sm.B[0])) == N)
                 except AttributeError:

--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -2045,14 +2045,14 @@ class CMAEvolutionStrategy(interfaces.OOOptimizer):
                 # for TPA, set both vectors to the same length and don't
                 # ever keep the original length
                 arinj[0] *= self._random_rescaling_factor_to_mahalanobis_size(arinj[0]) / self.sigma
-                arinj[1] *= (sum(arinj[0]**2) / sum(arinj[1]**2))**0.5
+                arinj[1] *= (np.sum(arinj[0]**2) / np.sum(arinj[1]**2))**0.5
                 if not Mh.vequals_approximately(arinj[0], -arinj[1]):
                     utils.print_warning(
                         "mean_shift_samples, but the first two solutions"
                         " are not mirrors.",
                         "ask_geno", "CMAEvolutionStrategy",
                         self.countiter)
-                    arinj[1] /= sum(arinj[0]**2)**0.5 / s1  # revert change
+                    arinj[1] /= np.sum(arinj[0]**2)**0.5 / s1  # revert change
             self.number_of_injections_delivered += len(arinj)
             assert (self.countiter < 2 or not self.mean_shift_samples
                     or self.number_of_injections_delivered >= 2)

--- a/cma/sampler.py
+++ b/cma/sampler.py
@@ -94,7 +94,7 @@ class GaussStandardConstant(GaussSampler):
         return x
 
     def norm(self, x):
-        return sum(self.transform_inverse(x)**2)**0.5
+        return np.sqrt(np.sum(self.transform_inverse(x)**2))
 
     def __imul__(self, factor):
         """variance multiplier"""

--- a/cma/sigma_adaptation.py
+++ b/cma/sigma_adaptation.py
@@ -68,7 +68,7 @@ class CMAAdaptSigmaBase(object):
         self._update_ps(es)
         if self.ps is None:
             return True
-        squared_sum = sum(self.ps**2) / (1 - (1 - self.cs)**(2 * es.countiter))
+        squared_sum = np.sum(self.ps**2) / (1 - (1 - self.cs)**(2 * es.countiter))
         # correction with self.countiter seems not necessary,
         # as pc also starts with zero
         return squared_sum / es.N - 1 < 1 + 4. / (es.N + 1)

--- a/cma/sigma_adaptation.py
+++ b/cma/sigma_adaptation.py
@@ -419,7 +419,7 @@ class CMAAdaptSigmaTPA(CMAAdaptSigmaBase):
             self.initialized = True
         if 1 < 3:
             f_vals = np.asarray(function_values)
-            z = sum(f_vals < f_vals[1]) - sum(f_vals < f_vals[0])
+            z = np.sum(f_vals < f_vals[1]) - np.sum(f_vals < f_vals[0])
             z /= len(f_vals) - 1  # z in [-1, 1]
         elif 1 < 3:
             # use the ranking difference of the mirrors for adaptation

--- a/cma/utilities/utils.py
+++ b/cma/utilities/utils.py
@@ -503,17 +503,17 @@ class SolutionDict(DerivedDictBase):
         self.data_with_same_key = {}
         self.last_iteration = 0
     @staticmethod
-    def key(x):
+    def _hash(x):
+        return x
+    def key(self, x):
         """compute key of ``x``"""
-        # numpy fast path
-        if type(x) is np.ndarray:
-            return hash(x.data.tobytes())
-        # fall-back to default path
         try:
-            return tuple(x)
-            # using sum(x) is slower, using x[0] is slightly faster
-        except TypeError:
-            return x
+            return self._hash(np.ascontiguousarray(x).data.tobytes())  # much faster than tuple(.)
+        except AttributeError:
+            try:
+                return self._hash(tuple(x))  # using sum(x) is slower, using x[0] is slightly faster
+            except TypeError:
+                return self._hash(x)
     def __setitem__(self, key, value):
         """define ``self[key] = value``"""
         key = self.key(key)

--- a/cma/utilities/utils.py
+++ b/cma/utilities/utils.py
@@ -502,8 +502,13 @@ class SolutionDict(DerivedDictBase):
         super(SolutionDict, self).__init__(*args, **kwargs)
         self.data_with_same_key = {}
         self.last_iteration = 0
-    def key(self, x):
+    @staticmethod
+    def key(x):
         """compute key of ``x``"""
+        # numpy fast path
+        if type(x) is np.ndarray:
+            return hash(x.data.tobytes())
+        # fall-back to default path
         try:
             return tuple(x)
             # using sum(x) is slower, using x[0] is slightly faster


### PR DESCRIPTION
The changes in this PR collectively lead to a performance improvement of Diagonal CMA by a factor 10.

The majority of changes are replacements of the type `sum` -> `np.sum`, `any` -> `np.any`, etc.

-----------
**Profiling evidence:**

Baseline:
![image](https://user-images.githubusercontent.com/5834577/70378361-aa4bdb00-191f-11ea-9199-5968508801b8.png)

Improvement to `SolutionDict.key()`:
![image](https://user-images.githubusercontent.com/5834577/70378371-c2235f00-191f-11ea-93ee-6bf4a44049ee.png)

Improvement to `GaussStandardConstant.norm()`:
![image](https://user-images.githubusercontent.com/5834577/70378374-d8c9b600-191f-11ea-90c4-bcaf50e89d59.png)

Improvement to `_CMAStopDict.update()`:
![image](https://user-images.githubusercontent.com/5834577/70378390-175f7080-1920-11ea-955c-6e6cbd08bec6.png)

Improvement to `_random_rescaling_factor_to_mahalanobis_size()`:
![image](https://user-images.githubusercontent.com/5834577/70378392-2fcf8b00-1920-11ea-81f7-4a80acae7b76.png)

Improvement to `alleviate_conditioning_in_coordinates()`:
![image](https://user-images.githubusercontent.com/5834577/70378403-555c9480-1920-11ea-875b-522b359c68a0.png)

Improvement to `ask_geno()`:
![image](https://user-images.githubusercontent.com/5834577/70378419-6efddc00-1920-11ea-9fa3-b3febc431116.png)

Improvement to `hsig()`:
![image](https://user-images.githubusercontent.com/5834577/70378426-84730600-1920-11ea-87ad-1b9dfb5bd2a2.png)

Improvement to `CMAAdaptSigmaTPA.update()`:
![image](https://user-images.githubusercontent.com/5834577/70378435-9eace400-1920-11ea-88c9-c8cb5fd91c3f.png)
