### PR TITLE
fixed a bug where supplied x0 is not being transformed

### DIFF
--- a/cma/wrapper.py
+++ b/cma/wrapper.py
@@ -68,6 +68,7 @@ else:
         if normalize: dimensions = list(map(lambda x: skopt.space.check_dimension(x, 'normalize'), dimensions))
         space = skopt.space.Space(dimensions)
         if x0 is None: x0 = space.transform(space.rvs())[0]
+        else: x0 = space.transform([x0])[0]
 
         tempdir = tempfile.mkdtemp()
         xi, yi = [], []


### PR DESCRIPTION
When x0 is None, the initial values will be 

1. randomly sampled from the space
2. transformed (normalized)

However, when x0 is provided, x0 is not being transformed and directly fed into the CMA model.

All the ``Xi``s are supposed to be transformed (e.g. normalize) before being presented to the CMA model so that the CMA model can solve the optimization problem in the normalized space. But the current implementation is not transforming provided ``x0`` and ``x0`` is directly fed into the CMA model.
This pull request will fix this by applying the transformation when ``x0`` is supplied.