### PR TITLE
Fix BoundaryHandlerBase.repair() return value

### DIFF
--- a/cma/constraints_handler.py
+++ b/cma/constraints_handler.py
@@ -82,6 +82,7 @@ class BoundaryHandlerBase(object):
                         x = np.array(x, copy=True)
                         copy = False
                     x[i] = self.bounds[ib][idx]
+        return x
 
     def inverse(self, y, copy_if_changed=True):
         """inverse of repair if it exists, at least it should hold


### PR DESCRIPTION
`BoundaryHandlerBase.repair()` currently always return `None` rather than the repaired `x`. This PR fixes this by returning the repaired `x`.