### PR TITLE
ensure unambiguous static return type for es.popsize

### DIFF
--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -3764,7 +3764,6 @@ class _CMAParameters(object):
         self.N = N
         if ccovfac == 1:
             ccovfac = opts['CMA_on']  # that's a hack
-        self.popsize = None  # declaring the attribute, not necessary though
         self.set(opts, ccovfac=ccovfac, verbose=verbose)
 
     def set(self, opts, popsize=None, ccovfac=1, verbose=True):

--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -3764,6 +3764,7 @@ class _CMAParameters(object):
         self.N = N
         if ccovfac == 1:
             ccovfac = opts['CMA_on']  # that's a hack
+        self.popsize = None  # type: int - declaring the attribute, not necessary though
         self.set(opts, ccovfac=ccovfac, verbose=verbose)
 
     def set(self, opts, popsize=None, ccovfac=1, verbose=True):


### PR DESCRIPTION
Initializing `self.popsize = None` only to set it just below to its true `int` value confuses static type checkers into concluding that `popsize` can be either `None` or `int`. (Even though the value is always `int` after instantiation.)

As a result, user code like `es.popsize + 1` produces type checking errors because an integer (`1`) cannot be added to `None`.

The easiest solution is to remove the unnecessary initialization.