### PR TITLE
Fixed one range call that caused the feed_for_resume function crash.

### DIFF
--- a/cma/evolution_strategy.py
+++ b/cma/evolution_strategy.py
@@ -3396,7 +3396,7 @@ class CMAEvolutionStrategy(interfaces.OOOptimizer):
             raise ValueError('number of solutions ' + str(len(X)) +
                     ' must be a multiple of popsize (lambda) ' +
                     str(popsize))
-        for i in rglen((X) / popsize):
+        for i in range(len(X) // popsize):
             # feed in chunks of size popsize
             self.ask()  # a fake ask, mainly for a conditioned calling of
                         # updateBD and secondary to get possibly the same


### PR DESCRIPTION
I changed one range call so that the feed_for_resume function doesn't crash.

rglen((X) / popsize) crashed when X was a list, if X were a numpy array it would lead to incorrect behavior.