### PR TITLE
pyproject.toml: fix license keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version",  # see tool.setuptools.dynamic below
            # "readme",
           ]
 readme = "README.txt"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "optimization",
     "CMA-ES",


### PR DESCRIPTION
Fixes
```
alueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```