### PR TITLE
ISSUE #312: Overriding xsemilog if plot_mean provided

### DIFF
--- a/cma/logger.py
+++ b/cma/logger.py
@@ -1008,7 +1008,11 @@ class CMADataLogger(interfaces.BaseDataLogger):
 
         subplot(2, 2 + addcols, 2)
         if plot_mean:
-            self.plot_mean(iabscissa, x_opt, xsemilog=False if plot_mean=='linear' else xsemilog, xnormalize=xnormalize)
+            if plot_mean == "log":
+                xsemilog = True
+            elif plot_mean == "linear":
+                xsemilog = False
+            self.plot_mean(iabscissa, x_opt, xsemilog=xsemilog, xnormalize=xnormalize)
         else:
             self.plot_xrecent(iabscissa, x_opt, xsemilog=xsemilog, xnormalize=xnormalize)
         pyplot.xlabel('')


### PR DESCRIPTION
Regarding open issue #312.
This makes `es.plot(plot_mean='log')` plot the same as `cma.plot(plot_mean='log')`, i.e. log scale in the mean plot. 
Haven't opened a pull request here previously so don't know if it is discouraged, in that case I will take it down! :)